### PR TITLE
Exit scripts gracefully

### DIFF
--- a/src/leiningen/exec.clj
+++ b/src/leiningen/exec.clj
@@ -1,5 +1,6 @@
 (ns leiningen.exec
   (:require [leiningen.core.eval  :as eval]
+            [leiningen.core.main  :as main]
             [cemerick.pomegranate :as pome]))
 
 
@@ -54,7 +55,7 @@ Executable Clojure script files should have the following on the first line:
     ;; else eval without project
     (load-reader *in*))
   (flush)
-  0)
+  (main/exit 0))
 
 
 (defn eval-sexp
@@ -66,7 +67,7 @@ Executable Clojure script files should have the following on the first line:
     ;; else eval without project
     (load-string sexp-str))
   (flush)
-  0)
+  (main/exit 0))
 
 
 (defn eval-script
@@ -83,7 +84,7 @@ Executable Clojure script files should have the following on the first line:
     (binding [*command-line-args* (read-string script-argstr)]
       (load-file script-path)))
   (flush)
-  0)
+  (main/exit 0))
 
 
 (defmacro in


### PR DESCRIPTION
Hello,

This is my first pull request, so bear with me :)  This changeset addresses an issue I noticed today when running lein-exec:

```
$ lein exec -e '(println "asdf")'
asdf
WARNING: using numeric exit values in plugins is deprecated.
Plugins should use leiningen.core.main/abort instead.
Support for this will be removed before the stable 2.0.0 release.
exec failed.
```

I'm running

```
$ lein version
Leiningen 2.0.0-preview8 on Java 1.7.0_05 Java HotSpot(TM) 64-Bit Server VM
```

with lein-exec 0.2.0.
