### PR TITLE
deps accepts :repositories keyword

### DIFF
--- a/src/leiningen/exec.clj
+++ b/src/leiningen/exec.clj
@@ -10,13 +10,14 @@
   Example:
     (use '[leiningen.exec :only (deps)])
     (deps '[[compojure \"1.0.1\"]
-            [org.clojure/java.jdbc \"0.1.0\"]])"
-  [the-deps]
+            [org.clojure/java.jdbc \"0.1.0\"]]
+          :repositories {\"jboss\" \"https://repository.jboss.org/nexus/content/repositories/\"})"
+  [the-deps & {:keys [repositories]}]
   (pome/add-dependencies
-   :coordinates  the-deps
-   :repositories (merge cemerick.pomegranate.aether/maven-central
-                        {"clojars" "http://clojars.org/repo"})))
-
+    :coordinates  the-deps
+    :repositories (merge cemerick.pomegranate.aether/maven-central
+                         {"clojars" "http://clojars.org/repo"}
+                         repositories)))
 
 (defn show-help
   []


### PR DESCRIPTION
This commit add support for local repositories.

``` clojure
(deps '[[korma "0.3.0-RC2"]
        [mysql/mysql-connector-java "5.1.22"]]
      :repositories {"jboss" "https://repository.jboss.org/nexus/content/repositories/"})
```
