### PR TITLE
adjusted bash scripts to send an absolute path to lein-exec, which fixes...

### DIFF
--- a/lein-exec
+++ b/lein-exec
@@ -3,7 +3,7 @@
 if [[ $1 =~ ^[~\/] ]]
 then
   # its already an absolute path
-  lein exec $@
+  lein exec "$@"
 else
   # This is a relative path, so make it absolute,
   # using the current directory as the base.

--- a/lein-exec-p
+++ b/lein-exec-p
@@ -3,7 +3,7 @@
 if [[ $1 =~ ^[~\/] ]]
 then
   # its already an absolute path
-  lein exec -p $@
+  lein exec -p "$@"
 else
   # This is a relative path, so make it absolute,
   # using the current directory as the base.


### PR DESCRIPTION
... an error where it would not find the file, if it was called from a sub directory of surrounding leiningen project

Hi  kumarshantanu :) .

Thanks for this very useful tool.

I found myself getting `FileNotFound` errors when calling `lein-exec` from a subfolder.
Say I have a project and all my scripts are in a `scripts` subdirectory. If I try to run `lein-exec` from that sub directory it would not find the according script file.
That is probably due to the way [load-file](http://grimoire.arrdem.com/1.6.0/clojure.core/load_DASH_file/) works, which assumes all path to be relative to the JVM executing the `lein-exec`. Sadly the JVM executing the script has its root in the folder above.

I'm happy about any feedback.

I would be very happy if you could integrate some fix for this issue into the next release.

Cheers,
Waldemar
