### PR TITLE
Fixes typo in docstring on line 79.

### DIFF
--- a/src/leiningen/exec.clj
+++ b/src/leiningen/exec.clj
@@ -76,7 +76,7 @@
 
 
 (defn ^:no-project-needed exec
-  "Execute Clojure S-expresions from command-line or scripts.
+  "Execute Clojure S-expressions from command-line or scripts.
 
 Usage:
     lein exec [-p]


### PR DESCRIPTION
![leinexec](https://cloud.githubusercontent.com/assets/4407459/6315129/0133aada-ba1e-11e4-94aa-c6e396fbb49a.jpg)
