### PR TITLE
Added local-repo and mirrors from leiningen user profile

### DIFF
--- a/src/leiningen/exec.clj
+++ b/src/leiningen/exec.clj
@@ -2,6 +2,7 @@
   (:require [leiningen.core.eval  :as eval]
             [leiningen.help       :as help]
             [leiningen.core.main  :as main]
+            [leiningen.core.project :as project]
             [cemerick.pomegranate :as pome]))
 
 
@@ -14,11 +15,14 @@
             [org.clojure/java.jdbc \"0.1.0\"]]
           :repositories {\"jboss\" \"https://repository.jboss.org/nexus/content/repositories/\"})"
   [the-deps & {:keys [repositories]}]
-  (pome/add-dependencies
-    :coordinates  the-deps
-    :repositories (merge cemerick.pomegranate.aether/maven-central
-                         {"clojars" "http://clojars.org/repo"}
-                         repositories)))
+  (let [{:keys [local-repo mirrors]} (:user (project/init-project (project/read-profiles nil)))]
+    (pome/add-dependencies
+      :coordinates  the-deps
+      :repositories (merge cemerick.pomegranate.aether/maven-central
+                           {"clojars" "http://clojars.org/repo"}
+                           repositories)
+      :local-repo local-repo
+      :mirrors mirrors)))
 
 
 (defn show-help


### PR DESCRIPTION
This addresses Issue #21.

It works as I would expect it to, but it's my first time in the Leiningen codebase, so I'm not sure if I got it all right. I only looked in the `:user` profile, but I guess there could also be a `:system` profile. I didn't see how to get a merged project map of all active profiles. Hence, I just picked `:user`