### PR TITLE
Fixed markdown for link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ Or, include as a dev-dependency:
 
 This blog post covers lein-exec with examples:
 
-[http://charsequence.blogspot.in/2012/04/scripting-clojure-with-leiningen-2.html]
-(http://charsequence.blogspot.in/2012/04/scripting-clojure-with-leiningen-2.html)
+[Scripting Clojure with Leiningen 2](http://charsequence.blogspot.in/2012/04/scripting-clojure-with-leiningen-2.html)
 
 #### Synopsis
 


### PR DESCRIPTION
Fixed markdown for link. There was a hard line break. Also added the Articles title for the link.